### PR TITLE
Fix 'Identyficable' typo

### DIFF
--- a/src/auth/contracts/can-affect.contact.ts
+++ b/src/auth/contracts/can-affect.contact.ts
@@ -1,6 +1,6 @@
 import { User } from '../../user/entities/user.entity';
-import { Identyficable } from 'src/common/interfaces/identyficable';
+import { Identifiable as Identifiable } from 'src/common/interfaces/identifiable';
 
 export interface CanAffect<Entity> {
-  canAffect(user: User, entity: Entity | Identyficable): boolean;
+  canAffect(user: User, entity: Entity | Identifiable): boolean;
 }

--- a/src/common/interfaces/identifiable.ts
+++ b/src/common/interfaces/identifiable.ts
@@ -1,7 +1,7 @@
 import { ApiExtraModels, ApiProperty } from '@nestjs/swagger';
 
 @ApiExtraModels()
-export class Identyficable {
+export class Identifiable {
   @ApiProperty({ type: Number, example: 1 })
   id: number;
 }

--- a/src/playlist-item/dto/create-playlist-item.dto.ts
+++ b/src/playlist-item/dto/create-playlist-item.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsNotEmpty, IsNotEmptyObject } from 'class-validator';
-import { Identyficable } from '../../common/interfaces/identyficable';
+import { Identifiable } from '../../common/interfaces/identifiable';
 
 export class CreatePlaylistItemDto {
   @ApiProperty({ example: '9zfXD8wjzfc', required: true })
@@ -10,5 +10,5 @@ export class CreatePlaylistItemDto {
 
   @ApiProperty({ required: true })
   @IsNotEmptyObject()
-  readonly playlist: Identyficable;
+  readonly playlist: Identifiable;
 }

--- a/src/playlist-item/dto/update-playlist-item.dto.ts
+++ b/src/playlist-item/dto/update-playlist-item.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, IsString, IsNotEmptyObject } from 'class-validator';
-import { Identyficable } from '../../common/interfaces/identyficable';
+import { Identifiable } from '../../common/interfaces/identifiable';
 
 export class UpdatePlaylistItemDto {
   @ApiProperty({ example: '0O6OCn4CXuw', required: false })
@@ -11,5 +11,5 @@ export class UpdatePlaylistItemDto {
   @ApiProperty({ required: false })
   @IsOptional()
   @IsNotEmptyObject()
-  readonly playlist?: Identyficable;
+  readonly playlist?: Identifiable;
 }

--- a/src/playlist-item/entities/playlist-item.entity.ts
+++ b/src/playlist-item/entities/playlist-item.entity.ts
@@ -1,9 +1,9 @@
 import { Entity, Column, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
 import { Playlist } from '../../playlist/entities/playlist.entity';
-import { Identyficable } from '../../common/interfaces/identyficable';
+import { Identifiable } from '../../common/interfaces/identifiable';
 
 @Entity()
-export class PlaylistItem implements Identyficable {
+export class PlaylistItem implements Identifiable {
   @PrimaryGeneratedColumn()
   public id: number;
 

--- a/src/playlist/dto/create-playlist-dto.ts
+++ b/src/playlist/dto/create-playlist-dto.ts
@@ -6,7 +6,7 @@ import {
   IsNotEmptyObject,
   IsAscii,
 } from 'class-validator';
-import { Identyficable } from '../../common/interfaces/identyficable';
+import { Identifiable } from '../../common/interfaces/identifiable';
 
 export class CreatePlaylistDto {
   @ApiProperty({ example: 'favorites', required: true, nullable: false })
@@ -17,5 +17,5 @@ export class CreatePlaylistDto {
   @ApiProperty({ required: true, nullable: false })
   @IsDefined()
   @IsNotEmptyObject()
-  readonly user: Identyficable;
+  readonly user: Identifiable;
 }

--- a/src/playlist/dto/update-playlist-dto.ts
+++ b/src/playlist/dto/update-playlist-dto.ts
@@ -7,7 +7,7 @@ import {
   IsOptional,
   IsAscii,
 } from 'class-validator';
-import { Identyficable } from '../../common/interfaces/identyficable';
+import { Identifiable } from '../../common/interfaces/identifiable';
 
 export class UpdatePlaylistDto {
   @ApiProperty({ example: 'favourite', required: false, nullable: false })
@@ -20,5 +20,5 @@ export class UpdatePlaylistDto {
   @IsOptional()
   @IsDefined()
   @IsNotEmptyObject()
-  readonly user?: Identyficable;
+  readonly user?: Identifiable;
 }

--- a/src/playlist/entities/playlist.entity.ts
+++ b/src/playlist/entities/playlist.entity.ts
@@ -7,10 +7,10 @@ import {
 } from 'typeorm';
 import { User } from '../../user/entities/user.entity';
 import { PlaylistItem } from '../../playlist-item/entities/playlist-item.entity';
-import { Identyficable } from '../../common/interfaces/identyficable';
+import { Identifiable } from '../../common/interfaces/identifiable';
 
 @Entity()
-export class Playlist implements Identyficable {
+export class Playlist implements Identifiable {
   @PrimaryGeneratedColumn()
   public id: number;
   @Column()

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -1,9 +1,9 @@
 import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
 import { Playlist } from '../../playlist/entities/playlist.entity';
-import { Identyficable } from '../../common/interfaces/identyficable';
+import { Identifiable } from '../../common/interfaces/identifiable';
 
 @Entity()
-export class User implements Identyficable {
+export class User implements Identifiable {
   @PrimaryGeneratedColumn()
   public id: number;
 


### PR DESCRIPTION
Changed all occurences of `Identyficable` to `Identifiable` and their lowercase couterparts also.