### PR TITLE
Top user titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "docker:dev:up": "docker-compose -f ./docker/development/docker-compose.yml --project-directory ./ up",
     "docker:dev:down": "docker-compose -f ./docker/development/docker-compose.yml --project-directory ./ down",
     "docker:dev:attach": "docker-compose -f ./docker/development/docker-compose.yml --project-directory ./ exec app /bin/sh",
-    "nest-dep-graph": "node node_modules/nestjs-dependency-graph/dist/index.js dist/app/app.module.js"
+    "nest-dep-graph": "node node_modules/nestjs-dependency-graph/dist/index.js dist/app.module.js"
   },
   "dependencies": {
     "@nestjs/common": "^6.10.14",

--- a/src/playlist/playlist.controller.ts
+++ b/src/playlist/playlist.controller.ts
@@ -21,7 +21,6 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { AuthUser } from '../auth/decorators/auth-user.decorator';
 import { User } from '../user/entities/user.entity';
 
-
 @ApiTags('playlists')
 @Controller('playlists')
 @ApiBearerAuth()
@@ -35,7 +34,7 @@ export class PlaylistController {
   @UseGuards(new JwtAuthGuard())
   @Get()
   async findAll(@AuthUser() authUser: User) {
-    if(!(await this.playlistService.canAffect(authUser, { id: 0} ))) {
+    if (!(await this.playlistService.canAffect(authUser, { id: 0 }))) {
       throw new ForbiddenException();
     }
 
@@ -46,7 +45,7 @@ export class PlaylistController {
   @UseGuards(new JwtAuthGuard())
   @Get(':id')
   async findById(@Param('id') id: number, @AuthUser() authUser: User) {
-    if(!(await this.playlistService.canAffect(authUser, { id: id} ))) {
+    if (!(await this.playlistService.canAffect(authUser, { id: id }))) {
       throw new ForbiddenException();
     }
     const data = await this.playlistService.findById(id);
@@ -56,11 +55,8 @@ export class PlaylistController {
 
   @UseGuards(new JwtAuthGuard())
   @Get(':id/playlist-items')
-  async findPlaylistItems(
-    @Param('id') id: number, 
-    @AuthUser() authUser: User,
-  ) {
-    if(!(await this.playlistService.canAffect(authUser, { id: id} ))) {
+  async findPlaylistItems(@Param('id') id: number, @AuthUser() authUser: User) {
+    if (!(await this.playlistService.canAffect(authUser, { id: id }))) {
       throw new ForbiddenException();
     }
     const data = await this.playlistItemService.findForPlaylist(id);
@@ -71,12 +67,12 @@ export class PlaylistController {
   @Post(':id/playlist-items')
   async storePlaylistItem(
     @Param('id') id: number,
-    @Body() createPlayListItemDTO: CreatePlaylistItemDto, 
+    @Body() createPlayListItemDTO: CreatePlaylistItemDto,
     @AuthUser() authUser: User,
-    ) {
-      if(!(await this.playlistService.canAffect(authUser, { id: id} ))) {
-        throw new ForbiddenException();
-      }
+  ) {
+    if (!(await this.playlistService.canAffect(authUser, { id: id }))) {
+      throw new ForbiddenException();
+    }
     createPlayListItemDTO.playlist.id = id;
     const data = await this.playlistItemService.create(createPlayListItemDTO);
     return { data };
@@ -86,8 +82,12 @@ export class PlaylistController {
   @Post()
   async store(
     @Body() createPlaylistDto: CreatePlaylistDto,
-    @AuthUser() authUser: User,) {
-    if(createPlaylistDto.user.id !== authUser.id && !(await this.playlistService.canAffect(authUser, { id: -1}))) {
+    @AuthUser() authUser: User,
+  ) {
+    if (
+      createPlaylistDto.user.id !== authUser.id &&
+      !(await this.playlistService.canAffect(authUser, { id: -1 }))
+    ) {
       throw new ForbiddenException();
     }
     const data = await this.playlistService.create(createPlaylistDto);
@@ -98,29 +98,29 @@ export class PlaylistController {
   @Put(':id')
   async update(
     @Param('id') id: number,
-    @Body() updatePlaylistDto: UpdatePlaylistDto, 
+    @Body() updatePlaylistDto: UpdatePlaylistDto,
     @AuthUser() authUser: User,
-    ) {
-
-      if(updatePlaylistDto.user !== undefined){
-        if(updatePlaylistDto.user.id !== authUser.id && !(await this.playlistService.canAffect(authUser, { id: -1}))) {
-          throw new ForbiddenException();
-        }
-      }
-
-      if(!(await this.playlistService.canAffect(authUser, { id: id} ))) {
+  ) {
+    if (updatePlaylistDto.user !== undefined) {
+      if (
+        updatePlaylistDto.user.id !== authUser.id &&
+        !(await this.playlistService.canAffect(authUser, { id: -1 }))
+      ) {
         throw new ForbiddenException();
       }
+    }
+
+    if (!(await this.playlistService.canAffect(authUser, { id: id }))) {
+      throw new ForbiddenException();
+    }
     const data = await this.playlistService.update(id, updatePlaylistDto);
     return { data };
   }
 
   @UseGuards(new JwtAuthGuard())
   @Delete(':id')
-  async delete(@Param('id') id: number, 
-  @AuthUser() authUser: User,
-  ) {
-    if(!(await this.playlistService.canAffect(authUser, { id: id } ))) {
+  async delete(@Param('id') id: number, @AuthUser() authUser: User) {
+    if (!(await this.playlistService.canAffect(authUser, { id: id }))) {
       throw new ForbiddenException();
     }
     const data = await this.playlistService.delete(id);

--- a/src/playlist/playlist.module.ts
+++ b/src/playlist/playlist.module.ts
@@ -1,5 +1,5 @@
 import { PlaylistService } from './playlist.service';
-import { Module, forwardRef } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { PlaylistController } from './playlist.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Playlist } from './entities/playlist.entity';
@@ -8,6 +8,9 @@ import { User } from '../user/entities/user.entity';
 import { ConfigModule } from '../config/config.module';
 import { PlaylistItem } from '../playlist-item/entities/playlist-item.entity';
 import { PlaylistItemService } from '../playlist-item/playlist-item.service';
+import { UserModule } from '../user/user.module';
+import { ProxyModule } from '../proxy/proxy.module';
+
 
 @Module({
   imports: [
@@ -15,6 +18,8 @@ import { PlaylistItemService } from '../playlist-item/playlist-item.service';
     TypeOrmModule.forFeature([User]),
     TypeOrmModule.forFeature([PlaylistItem]),
     ConfigModule,
+    ProxyModule,
+    UserModule,
   ],
   providers: [PlaylistService, UserService, PlaylistItemService],
   controllers: [PlaylistController],

--- a/src/playlist/playlist.service.ts
+++ b/src/playlist/playlist.service.ts
@@ -18,7 +18,7 @@ import { ConfigService } from '../config/config.service';
 export class PlaylistService implements CanAffect<Playlist>{
   constructor(
     @InjectRepository(Playlist)
-    private readonly playlistRepository: Repository<Playlist>, // PlaylistItemService
+    private readonly playlistRepository: Repository<Playlist>,
     @Inject(forwardRef(() => UserService))
     private readonly userService: UserService,
     private readonly configService: ConfigService,

--- a/src/proxy/proxy.service.ts
+++ b/src/proxy/proxy.service.ts
@@ -2,7 +2,7 @@ import { Injectable, HttpService } from '@nestjs/common';
 import { ConfigService } from '../config/config.service';
 import { Observable } from 'rxjs';
 import { AxiosResponse } from 'axios';
-import {map} from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 
 @Injectable()
 export class ProxyService {
@@ -17,10 +17,15 @@ export class ProxyService {
 
   private prepareRequest(ytID: string): string {
     const apiKey: string = this.config.getApiKey();
-    return this.ytEndpoint.concat(ytID).concat('&key=' + apiKey).concat('&part=' + this.requestParams);
+    return this.ytEndpoint
+      .concat(ytID)
+      .concat('&key=' + apiKey)
+      .concat('&part=' + this.requestParams);
   }
 
-  callYtApi(ytID: string) :Observable<JSON> {
-    return this.httpService.get(this.prepareRequest(ytID)).pipe(map(response => response.data));
+  callYtApi(ytID: string): Observable<JSON> {
+    return this.httpService
+      .get(this.prepareRequest(ytID))
+      .pipe(map(response => response.data));
   }
 }

--- a/src/proxy/proxy.service.ts
+++ b/src/proxy/proxy.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, HttpService } from '@nestjs/common';
 import { ConfigService } from '../config/config.service';
 import { Observable } from 'rxjs';
-import { AxiosResponse } from 'axios';
 import { map } from 'rxjs/operators';
 
 @Injectable()

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -32,7 +32,7 @@ export class UserController {
   @UseGuards(new JwtAuthGuard())
   @Get()
   async find(@AuthUser() authUser: User) {
-    if (!await this.usersService.canAffect(authUser, { id: 0 })) {
+    if (!(await this.usersService.canAffect(authUser, { id: 0 }))) {
       throw new ForbiddenException();
     }
     return { data: await this.usersService.findAll() };
@@ -41,7 +41,7 @@ export class UserController {
   @UseGuards(new JwtAuthGuard())
   @Get(':id')
   async findOne(@Param('id') id: number, @AuthUser() authUser: User) {
-    if (!await this.usersService.canAffect(authUser, { id: id })) {
+    if (!(await this.usersService.canAffect(authUser, { id: id }))) {
       throw new ForbiddenException();
     }
     return { data: await this.usersService.findById(id) };
@@ -59,7 +59,7 @@ export class UserController {
     @Body() updateUserDto: UpdateUserDto,
     @AuthUser() authUser: User,
   ) {
-    if (!await this.usersService.canAffect(authUser, { id: userId })) {
+    if (!(await this.usersService.canAffect(authUser, { id: userId }))) {
       throw new ForbiddenException();
     }
     const updatedUser = await this.usersService.update(userId, updateUserDto);
@@ -69,7 +69,7 @@ export class UserController {
   @UseGuards(new JwtAuthGuard())
   @Delete(':id')
   async delete(@Param('id') userId: number, @AuthUser() authUser: User) {
-    if (!await this.usersService.canAffect(authUser, { id: userId })) {
+    if (!(await this.usersService.canAffect(authUser, { id: userId }))) {
       throw new ForbiddenException();
     }
     const deletedUser = await this.usersService.delete(userId);
@@ -79,12 +79,26 @@ export class UserController {
   @UseGuards(new JwtAuthGuard())
   @Get(':id/playlists')
   async findPlaylists(@Param('id') userId: number, @AuthUser() authUser: User) {
-    if (!await this.usersService.canAffect(authUser, { id: userId })) {
+    if (!(await this.usersService.canAffect(authUser, { id: userId }))) {
       throw new ForbiddenException();
     }
     const foundPlaylists = await this.playlistService.findPlaylistsForUser(
       userId,
     );
     return { data: foundPlaylists };
+  }
+
+  @UseGuards(new JwtAuthGuard())
+  @Get(':id/top-titles/:limit')
+  async topTitles(
+    @Param('id') userId: number,
+    @AuthUser() authUser: User,
+    @Param('limit') limit: number,
+  ) {
+    if (!(await this.usersService.canAffect(authUser, { id: userId }))) {
+      throw new ForbiddenException();
+    }
+    const foundTop = await this.usersService.findTopTitles(userId, limit);
+    return { data: foundTop };
   }
 }

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, HttpModule } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -9,6 +9,9 @@ import { PlaylistService } from '../playlist/playlist.service';
 import { Playlist } from '../playlist/entities/playlist.entity';
 import { PlaylistItem } from '../playlist-item/entities/playlist-item.entity';
 import { PlaylistItemService } from '../playlist-item/playlist-item.service';
+import { ProxyService } from '../proxy/proxy.service';
+import { ProxyModule } from '../proxy/proxy.module';
+import { ConfigService } from '../config/config.service';
 
 @Module({
   imports: [
@@ -16,9 +19,13 @@ import { PlaylistItemService } from '../playlist-item/playlist-item.service';
     TypeOrmModule.forFeature([User]),
     TypeOrmModule.forFeature([Playlist]),
     TypeOrmModule.forFeature([PlaylistItem]),
+    HttpModule.register({
+      timeout: 5000,
+    }),
     ConfigModule,
+    ProxyModule,
   ],
-  providers: [UserService, PlaylistService, PlaylistItemService],
+  providers: [UserService, PlaylistService, PlaylistItemService, ConfigService, ProxyService],
   controllers: [UserController],
   exports: [UserService],
 })

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,22 +1,24 @@
-import { Module, forwardRef } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
 import { PassportModule } from '@nestjs/passport';
 import { ConfigModule } from '../config/config.module';
-import { PlaylistModule } from '../playlist/playlist.module';
 import { PlaylistService } from '../playlist/playlist.service';
 import { Playlist } from '../playlist/entities/playlist.entity';
+import { PlaylistItem } from '../playlist-item/entities/playlist-item.entity';
+import { PlaylistItemService } from '../playlist-item/playlist-item.service';
 
 @Module({
   imports: [
     PassportModule.register({ defaultStrategy: 'jwt' }),
     TypeOrmModule.forFeature([User]),
     TypeOrmModule.forFeature([Playlist]),
+    TypeOrmModule.forFeature([PlaylistItem]),
     ConfigModule,
   ],
-  providers: [UserService, PlaylistService],
+  providers: [UserService, PlaylistService, PlaylistItemService],
   controllers: [UserController],
   exports: [UserService],
 })

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -110,7 +110,7 @@ export class UserService implements CanAffect<User> {
     const topItems = foundItems.slice(foundItems.length - limit);
 
     // Map titles of top songs to playbackCount
-    const topSongs = [];
+    const topTitles = [];
     for (const item of topItems){
       const observable = this.proxyService.callYtApi(item.ytID)
       const ytApiResp = await observable.toPromise().then(result => result) as any;
@@ -118,10 +118,10 @@ export class UserService implements CanAffect<User> {
         throw new NotFoundException();
       }
       const title = ytApiResp.items[0].snippet.title;
-      topSongs.unshift({title: title, playbackCount: item.playbackCount});
+      topTitles.push({title: title, playbackCount: item.playbackCount});
     }
 
-    return topSongs;
+    return topTitles;
   }
 
   private async hashPassword(

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -75,6 +75,16 @@ export class PlaylistItemHelper {
     return createdPlaylistItem;
   }
 
+  static async updatePlaylistItem(server, authToken, playlistItemId, updatePlaylistItemDto){
+    const res = await request(server)
+      .put('/playlist-items/' + playlistItemId)
+      .set('Authorization', 'Bearer ' + authToken)
+      .send(updatePlaylistItemDto);
+
+    const createdPlaylistItem = res.body.data;
+    return createdPlaylistItem;
+  }
+
   static async deletePlaylistItem(server, authToken, playlistItemId) {
     const res = await request(server)
       .delete('/playlist-items/' + playlistItemId)

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -15,7 +15,7 @@ describe('User (e2e)', () => {
     lastname: 'Tester',
   };
 
-  let createdUserId: Number;
+  let createdUserId: number;
   let authToken;
 
   beforeAll(async () => {
@@ -40,9 +40,9 @@ describe('User (e2e)', () => {
   });
 
   it('/users (POST) - create user, invalid DTO', async () => {
-    let invalidUser = { username: 'someusername' }; // Missing other properties
+    const invalidUser = { username: 'someusername' }; // Missing other properties
 
-    const res = await request(app.getHttpServer())
+    await request(app.getHttpServer())
       .post('/users')
       .send(invalidUser)
       .expect(400);
@@ -78,7 +78,7 @@ describe('User (e2e)', () => {
   });
 
   it('/users (GET) - get all users', async () => {
-    const res = await request(app.getHttpServer())
+    await request(app.getHttpServer())
       .get('/users')
       .set('Authorization', 'Bearer ' + authToken)
       .expect(403);
@@ -97,7 +97,7 @@ describe('User (e2e)', () => {
   });
 
   it('/users/:id (PUT) - update created user', async () => {
-    let dto = { firstname: 'Krzysztof', lastname: 'Krawczyk' };
+    const dto = { firstname: 'Krzysztof', lastname: 'Krawczyk' };
 
     const res = await request(app.getHttpServer())
       .put('/users/' + createdUserId)


### PR DESCRIPTION
`/users/:id/top-titles/:limit`
Implements a new endpoint for getting a specific user's top playlist items, represented as a list of `{title: 'title', playbackCount: 100}` pairs. Limited to the specified amount (`:limit`).